### PR TITLE
Task.7-3 記事一覧の実装【Article に関する API 実装】

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
-gem 'active_model_serializers', '~> 0.10.15'
+gem 'active_model_serializers', '~> 0.10.0'
 gem 'devise_token_auth'
 gem 'devise'
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  active_model_serializers (~> 0.10.15)
+  active_model_serializers (~> 0.10.0)
   annotate
   bootsnap (>= 1.4.4)
   byebug

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ArticlesController < Api::V1::BaseApiController
+  def index
+    articles = Article.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,3 @@
 class Api::V1::BaseApiController < ApplicationController
+  protect_from_forgery with: :null_session
 end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'auth'
-      resources :articles
+      resources :articles, only: [:index]
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,10 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+user = User.first || User.create!(name: "テストユーザー", email: "test@example.com", password: "password")
+Article.create!(
+  title: "サンプル記事",
+  body: "これはサンプルの記事です。",
+  user: user
+)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /api/v1/articles" do
+    before do
+      create_list(:article, 3, updated_at: Time.current + 1.day)  # 更新日時も指定
+    end
+
+    it "記事一覧を取得できる" do
+      get "/api/v1/articles"
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+
+      expect(json.length).to eq(3)
+      expect(json[0]).to include("id", "title", "updated_at") # 本文が含まれていない
+      expect(json[0]).not_to include("body") # 本文がないことを確認
+    end
+  end
+end


### PR DESCRIPTION
amsを0.10に指定
Serializer 作成
コントローラー作成・修正
routes.rb を定義
Base コントローラ
spec/requests/api/v1/articles_spec.rbに「GET /api/v1/articles にアクセスしたとき、記事一覧が取得できて、かつ body（本文）が含まれていないこと」を確認するためのコードを追加