### PR TITLE
Task. 9-5 既存 API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticlesController < Api::V1::BaseApiController
-  before_action :authenticate_api_v1_user!, only: [:create, :update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
   before_action :set_article, only: [:show, :update, :destroy]
 
   def index

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,7 +1,18 @@
 class Api::V1::BaseApiController < ApplicationController
+  include DeviseTokenAuth::Concerns::SetUserByToken  # ←これ入ってる？
+  # protect_from_forgery with: :null_session           # APIならこれ or skip_before_action
   # protect_from_forgery with: :null_session
 
+  # Expose devise_token_auth helpers with generic names in API layer
   def current_user
-    User.first
+    current_api_v1_user
+  end
+
+  def authenticate_user!
+    authenticate_api_v1_user!
+  end
+
+  def user_signed_in?
+    api_v1_user_signed_in?
   end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -2,22 +2,8 @@ require 'rails_helper'
 
 
 RSpec.describe "Api::V1::Articles", type: :request do
-  def auth_headers_for(user)
-    post "/api/v1/auth/sign_in", params: {
-      email: user.email,
-      password: user.password
-    }
-
-    {
-      'access-token' => response.headers['access-token'],
-      'client' => response.headers['client'],
-      'uid' => response.headers['uid'],
-      'Content-Type' => 'application/json'
-    }
-  end
-
   let(:user) { create(:user, password: 'password') }
-let(:headers) { auth_headers_for(user) }
+  let(:headers) { user.create_new_auth_token.merge('Content-Type' => 'application/json') }
 
 it "記事を作成できる" do
   post "/api/v1/articles", params: {
@@ -72,11 +58,6 @@ end
   describe "POST /api/v1/articles" do
     let!(:user) { create(:user) }
 
-    before do
-      # current_user をテスト時だけスタブ
-      allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(user)
-    end
-
     it "記事を作成できる" do
       post "/api/v1/articles", params: {
         article: {
@@ -97,10 +78,6 @@ end
   describe "PATCH /api/v1/articles/:id" do
     let(:user) { create(:user) }
     let(:article) { create(:article, user: user, title: "Before", body: "Before body") }
-
-    before do
-      allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(user)
-    end
 
     it "自分の記事を更新できる" do
       patch "/api/v1/articles/#{article.id}", params: {


### PR DESCRIPTION
概要

APIでdevise_token_authの認証メソッド（current_user, authenticate_user!, user_signed_in?）を利用できるように修正しました。 これにより、ログイン必須のAPIで共通の認証処理を適用し、テストコードでもトークンヘッダーを統一的に生成できるようになりました。

⸻

変更内容
	•	Api::V1::BaseApiController
	•	ダミー実装のcurrent_userを削除
	•	include DeviseTokenAuth::Concerns::SetUserByTokenを追加
	•	current_api_v1_userなどスコープ付きメソッドをラップしてcurrent_user等として利用可能に
	•	Api::V1::ArticlesController
	•	authenticate_api_v1_user! を authenticate_user! に置き換え
	•	テストコード（articles_spec.rb）
	•	認証が必要なリクエストで user.create_new_auth_token を使用してヘッダーを生成
	•	不要だった current_user のスタブ削除

⸻

目的
	•	コントローラごとに異なる認証メソッドの記述を統一し、可読性・保守性を向上
	•	APIテストでの認証ヘッダー生成を簡潔にする
	•	devise_token_authの提供機能を正しく活用

⸻

テスト
	•	bundle exec rspec 実行し全テスト通過
	•	記事の作成・更新・削除がログイン状態でのみ成功することを確認
	•	未ログインや不正トークンでリクエストが弾かれることを確認