### PR TITLE
Task. 11-1 Article model に下書き機能を追加【下書き機能の実装】

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default("draft"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -11,6 +12,7 @@
 #
 # Indexes
 #
+#  index_articles_on_status   (status)
 #  index_articles_on_user_id  (user_id)
 #
 # Foreign Keys
@@ -23,4 +25,6 @@ class Article < ApplicationRecord
   has_many :article_likes, class_name: 'ArticleLike', dependent: :destroy
 
   validates :title, :body, presence: true
+
+  enum status: { draft: 0, published: 1 }
 end

--- a/db/migrate/20250808065758_add_status_to_articles.rb
+++ b/db/migrate/20250808065758_add_status_to_articles.rb
@@ -1,0 +1,6 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :status, :integer, default: 0, null: false
+    add_index :articles, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_07_09_032529) do
+ActiveRecord::Schema.define(version: 2025_08_08_065758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,8 @@ ActiveRecord::Schema.define(version: 2025_07_09_032529) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
+    t.index ["status"], name: "index_articles_on_status"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default("draft"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -11,6 +12,7 @@
 #
 # Indexes
 #
+#  index_articles_on_status   (status)
 #  index_articles_on_user_id  (user_id)
 #
 # Foreign Keys
@@ -21,6 +23,7 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
+    status { :draft }
     association :user
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default("draft"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -11,6 +12,7 @@
 #
 # Indexes
 #
+#  index_articles_on_status   (status)
 #  index_articles_on_user_id  (user_id)
 #
 # Foreign Keys
@@ -33,5 +35,21 @@ RSpec.describe Article, type: :model do
   it "is invalid without a body" do
     article = build(:article, body: nil)
     expect(article).not_to be_valid
+  end
+
+  describe "status" do
+    it "下書き記事として保存できる" do
+      article = build(:article, status: :draft)
+      expect(article).to be_valid
+      article.save!
+      expect(article.draft?).to be_truthy
+    end
+
+    it "公開記事として保存できる" do
+      article = build(:article, status: :published)
+      expect(article).to be_valid
+      article.save!
+      expect(article.published?).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
## 概要
Article モデルに下書き機能を追加しました。
enum を利用し、「下書き（draft）」と「公開（published）」の 2 状態を持たせました。

## 実装内容
- マイグレーションで `status` カラムを追加（integer型、デフォルト0、NOT NULL、index付き）
- Article モデルに `enum status: { draft: 0, published: 1 }` を定義
- FactoryBot に `status { :draft }` を追加
- モデルテストで以下を確認
  - 下書き記事として保存できる
  - 公開記事として保存できる

## 注意点
- API で status を送信する場合は Strong Parameters に `:status` を追加する必要あり

## 動作確認
- RSpec モデルテストが全てパスすることを確認
- 手動で status を指定して記事作成・更新が可能なことを確認