### PR TITLE
Task. 11-2 既存のAPIの修正【下書き機能の実装】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,13 +3,15 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   before_action :set_article, only: [:show, :update, :destroy]
 
   def index
-    articles = Article.order(updated_at: :desc)
+    articles = Article.published.order(updated_at: :desc)
     render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.published.find(params[:id])
     render json: article, serializer: Api::V1::ArticleSerializer
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "記事が見つかりません" }, status: :not_found
   end
 
   def create
@@ -35,7 +37,6 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
     end
   end
 
-
   def destroy
     if @article.user_id == current_user.id
       @article.destroy
@@ -48,7 +49,7 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   private
 
   def article_params
-    params.require(:article).permit(:title, :body)
+    params.require(:article).permit(:title, :body, :status)
   end
 
   def set_article

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user
 
   class UserSerializer < ActiveModel::Serializer

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,94 +1,128 @@
 require 'rails_helper'
 
-
 RSpec.describe "Api::V1::Articles", type: :request do
   let(:user) { create(:user, password: 'password') }
   let(:headers) { user.create_new_auth_token.merge('Content-Type' => 'application/json') }
 
-it "記事を作成できる" do
-  post "/api/v1/articles", params: {
-    article: {
-      title: "タイトル",
-      body: "本文"
-    }
-  }.to_json, # ← JSON形式で渡す
-  headers: headers.merge({ 'Content-Type' => 'application/json' })
-
-  expect(response).to have_http_status(:created)
-end
   describe "GET /api/v1/articles" do
     before do
-      create_list(:article, 3, updated_at: Time.current + 1.day)  # 更新日時も指定
+      create_list(:article, 3, status: :published, updated_at: Time.current + 1.day)
+      create_list(:article, 2, status: :draft, updated_at: Time.current + 1.day)
     end
 
-    it "記事一覧を取得できる" do
+    it "公開記事一覧のみ取得できる" do
       get "/api/v1/articles"
 
       expect(response).to have_http_status(:ok)
 
       json = JSON.parse(response.body)
 
-      expect(json.length).to eq(3)
-      expect(json[0]).to include("id", "title", "updated_at") # 本文が含まれていない
-      expect(json[0]).not_to include("body") # 本文がないことを確認
+      expect(json.length).to eq(3) # 公開記事のみ
+      expect(json[0]).to include("id", "title", "updated_at")
+      expect(json[0]).not_to include("body")
     end
   end
 
   describe "GET /api/v1/articles/:id" do
-    let(:article) { create(:article) }
+    let(:published_article) { create(:article, status: :published) }
+    let(:draft_article) { create(:article, status: :draft) }
 
-    it "記事の詳細情報を取得できる" do
-      get "/api/v1/articles/#{article.id}"
+    it "公開記事の詳細情報を取得できる" do
+      get "/api/v1/articles/#{published_article.id}"
 
       expect(response).to have_http_status(:ok)
 
       json = JSON.parse(response.body)
 
-      expect(json["id"]).to eq(article.id)
-      expect(json["title"]).to eq(article.title)
-      expect(json["body"]).to eq(article.body)
+      expect(json["id"]).to eq(published_article.id)
+      expect(json["title"]).to eq(published_article.title)
+      expect(json["body"]).to eq(published_article.body)
       expect(json["updated_at"]).to be_present
       expect(json["user"]).to include(
-        "id" => article.user.id,
-        "name" => article.user.name
+        "id" => published_article.user.id,
+        "name" => published_article.user.name
       )
+    end
+
+    it "下書き記事は取得できない" do
+      get "/api/v1/articles/#{draft_article.id}"
+
+      expect(response).to have_http_status(:not_found)
+      json = JSON.parse(response.body)
+      expect(json["error"]).to eq("記事が見つかりません")
     end
   end
 
   describe "POST /api/v1/articles" do
     let!(:user) { create(:user) }
 
-    it "記事を作成できる" do
+    it "下書き記事を作成できる" do
       post "/api/v1/articles", params: {
         article: {
-          title: "テストタイトル",
-          body: "テスト本文"
+          title: "下書きタイトル",
+          body: "下書き本文",
+          status: "draft"
         }
-      }.to_json, # ← JSON形式で渡す
+      }.to_json,
       headers: headers.merge({ 'Content-Type' => 'application/json' })
 
       expect(response).to have_http_status(:created)
 
       json = JSON.parse(response.body)
-      expect(json["title"]).to eq("テストタイトル")
-      expect(json["body"]).to eq("テスト本文")
+      expect(json["title"]).to eq("下書きタイトル")
+      expect(json["body"]).to eq("下書き本文")
+      expect(json["status"]).to eq("draft")
+    end
+
+    it "公開記事を作成できる" do
+      post "/api/v1/articles", params: {
+        article: {
+          title: "公開タイトル",
+          body: "公開本文",
+          status: "published"
+        }
+      }.to_json,
+      headers: headers.merge({ 'Content-Type' => 'application/json' })
+
+      expect(response).to have_http_status(:created)
+
+      json = JSON.parse(response.body)
+      expect(json["title"]).to eq("公開タイトル")
+      expect(json["body"]).to eq("公開本文")
+      expect(json["status"]).to eq("published")
+    end
+
+    it "statusを指定しない場合は下書きとして作成される" do
+      post "/api/v1/articles", params: {
+        article: {
+          title: "デフォルトタイトル",
+          body: "デフォルト本文"
+        }
+      }.to_json,
+      headers: headers.merge({ 'Content-Type' => 'application/json' })
+
+      expect(response).to have_http_status(:created)
+
+      json = JSON.parse(response.body)
+      expect(json["status"]).to eq("draft")
     end
   end
 
   describe "PATCH /api/v1/articles/:id" do
     let(:user) { create(:user) }
-    let(:article) { create(:article, user: user, title: "Before", body: "Before body") }
+    let(:article) { create(:article, user: user, title: "Before", body: "Before body", status: :draft) }
 
-    it "自分の記事を更新できる" do
+    it "自分の記事を更新できる（下書きから公開に変更）" do
       patch "/api/v1/articles/#{article.id}", params: {
-        article: { title: "After", body: "After body" }
-      }.to_json, # ← JSON形式
+        article: { title: "After", body: "After body", status: "published" }
+      }.to_json,
       headers: headers.merge({ 'Content-Type' => 'application/json' })
 
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)
       expect(json["title"]).to eq("After")
       expect(json["body"]).to eq("After body")
+      expect(json["status"]).to eq("published")
     end
 
     it "他人の記事は更新できない" do
@@ -97,7 +131,7 @@ end
 
       patch "/api/v1/articles/#{other_article.id}", params: {
         article: { title: "不正更新" }
-      }.to_json, # ← JSON形式
+      }.to_json,
       headers: headers.merge({ 'Content-Type' => 'application/json' })
 
       expect(response).to have_http_status(:forbidden)


### PR DESCRIPTION
記事モデルに下書き機能を追加し、公開記事のみ取得するAPI仕様に変更

⸻

変更内容
	1.	Articleモデル •	enum status: { draft: 0, published: 1 } を追加。 •	マイグレーションで status カラムを追加（デフォルト draft, NOT NULL, インデックス追加）。
	2.	APIコントローラー •	index / show を Article.published に変更し、下書きは取得不可に。 •	create / update で status パラメータを受け取れるように修正。
	3.	シリアライザー •	ArticleSerializer に status 属性を追加。 •	一覧用に ArticlePreviewSerializer を作成（本文なし）。
	4.	テスト（RSpec） •	公開記事のみ取得されることを確認。 •	下書きは404となることを確認。 •	下書き/公開記事の作成・更新・削除に関するテストを追加。

⸻

動作確認
	•	公開記事のみ /api/v1/articles と /api/v1/articles/:id で取得可能。
	•	記事作成時に status を "draft" または "published" として指定可能（未指定は draft）。
	•	下書きから公開への更新も可能。