### PR TITLE
Task. 9-5 既存 API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticlesController < Api::V1::BaseApiController
-  before_action :authenticate_user!, only: [:create, :update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy, :drafts, :show_draft]
   before_action :set_article, only: [:show, :update, :destroy]
 
   def index
@@ -44,6 +44,18 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
     else
       render json: { error: "権限がありません" }, status: :forbidden
     end
+  end
+
+  def drafts
+    articles = current_user.articles.draft.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+
+  def show_draft
+    article = current_user.articles.draft.find(params[:id])
+    render json: article, serializer: Api::V1::ArticleSerializer
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "下書き記事が見つかりません" }, status: :not_found
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,14 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth"
 
-      resources :articles
+      resources :articles do
+        collection do
+          get :drafts
+        end
+      end
+
+      # 下書き記事の詳細取得用のルート
+      get 'articles/drafts/:id', to: 'articles#show_draft'
     end
   end
 end


### PR DESCRIPTION
下書き記事の一覧・詳細取得 API の実装

概要
	•	ログインユーザー専用の下書き記事取得 API を実装
	•	一覧: GET /api/v1/articles/drafts
	•	詳細: GET /api/v1/articles/drafts/:id
	•	公開記事取得 API の仕様は変更なし

変更内容
	1.	ルーティング追加 •	/articles/drafts → 一覧取得 •	/articles/drafts/:id → 詳細取得
	2.	コントローラ修正 •	drafts アクション追加 •	show_draft アクション追加 •	認証フィルターに追加
	3.	シリアライザー修正 •	status 属性を追加
	4.	テスト追加 •	自分の下書きのみ取得可能なこと •	他人の下書きや公開記事は取得不可 •	未認証時は401

動作確認
	•	RSpec 全テストパス
	•	手動確認で正しいデータのみ返却されることを確認